### PR TITLE
fix: replace addons default export with named export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import { combineParameters } from '@storybook/client-api'
-import addons, { mockChannel, ArgTypes, Parameters, BaseDecorators } from '@storybook/addons'
+import { addons, mockChannel, ArgTypes, Parameters, BaseDecorators } from '@storybook/addons'
 import { Meta, Story, StoryContext } from '@storybook/vue'
 import decorateStory from './decorateStory'
 import type { ComponentOptions, VueConstructor } from 'vue'
@@ -85,9 +85,9 @@ export function composeStory<GenericArgs>(
       typeof component === 'string' ? { template: component } : component
 
     const {args} = context
-    cmp.props = Object.keys(context.argTypes) 
-   
-    // augment args with action methods. 
+    cmp.props = Object.keys(context.argTypes)
+
+    // augment args with action methods.
     // Either match the argTypesRegex parameter
     // or an argType with "action" property
     const matcher = globalStorybookConfig.parameters?.actions?.argTypesRegex
@@ -138,7 +138,7 @@ export function composeStory<GenericArgs>(
     for (const type of Object.keys(args)) {
       argTypes[type] = {}
     }
-    // merge with actual ArgTypes config 
+    // merge with actual ArgTypes config
     Object.assign(argTypes, story.argTypes, meta.argTypes, globalConfig.argTypes)
 
     return decorated({
@@ -155,7 +155,7 @@ export function composeStory<GenericArgs>(
       args,
     }) as ComponentOptions<any>
   }
-    
+
 }
 
 export function composeStories<


### PR DESCRIPTION
This PR replaces the default export with the named export for `addons`.

## Context
While migrating a Vue2 Component library from Storybook 6 to 7, the following error was returned:

```bash
TypeError: addons__default.setChannel is not a function from the @storybook/testing-vue package. 
```

While searching a bit for the issue I found this explanation: https://github.com/storybookjs/storybook/issues/20971

